### PR TITLE
Implement word mask scroll animation

### DIFF
--- a/brandon-custom-scripts.js
+++ b/brandon-custom-scripts.js
@@ -542,13 +542,20 @@
 
         const split = new SplitText(textParagraph, { type: "words" });
 
+        split.words.forEach(word => {
+          const mask = document.createElement('span');
+          mask.classList.add('brandon-word-mask');
+          mask.style.height = word.offsetHeight + 'px';
+          word.parentNode.insertBefore(mask, word);
+          mask.appendChild(word);
+        });
+
         if (split.words.length > 0) {
-          masterTimeline.fromTo(split.words,
-            { opacity: 1, y: 0, filter: 'none' },
+          masterTimeline.fromTo(
+            split.words,
+            { y: 0 },
             {
-              y: -40,
-              opacity: 0,
-              filter: 'blur(8px)',
+              y: (i, target) => -target.offsetHeight,
               duration: 0.6,
               ease: "power2.in",
               stagger: { each: 0.03, from: "start" }

--- a/functions.php
+++ b/functions.php
@@ -65,7 +65,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-scripts',
         get_stylesheet_directory_uri() . '/brandon-custom-scripts.js',
         array('brandon-p5', 'brandon-gsap-ce', 'brandon-gsap-st', 'brandon-gsap-stg'),
-        '3.1.4', // Incremented version
+        '3.1.5', // Incremented version
         true
     );
 }

--- a/style.css
+++ b/style.css
@@ -425,8 +425,14 @@ div.smp-code a.brandon-quicklink-style {
 .brandon-reveal-link-js.brandon-arrow-diag-down:hover .brandon-arrow-one { 
     transform: translate(150%, 150%); /* Exits bottom-right */
 }
-.brandon-reveal-link-js.brandon-arrow-diag-down:hover .brandon-arrow-two { 
+.brandon-reveal-link-js.brandon-arrow-diag-down:hover .brandon-arrow-two {
     transform: translate(-50%, -50%); /* Enters at center */
+}
+
+.brandon-word-mask {
+    display: inline-block;
+    overflow: hidden;
+    vertical-align: top;
 }
 
 


### PR DESCRIPTION
## Summary
- add `.brandon-word-mask` style for masking words during animation
- wrap SplitText words with mask elements and animate them upward
- update hero scroll animation parameters
- bump JS enqueue version for cache busting

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b94861720833184b37ee5a7de9a94