### PR TITLE
Switch to SVG arrows

### DIFF
--- a/brandon-custom-scripts.js
+++ b/brandon-custom-scripts.js
@@ -486,16 +486,31 @@
       if (hasArrow) {
         const arrowClass = Array.from(module.classList).find(cls => cls.startsWith('with-arrow-'));
         const arrowDirection = arrowClass.replace('with-arrow-', '');
-        const arrowChar = arrowDirection === 'diag-down' ? '↘' : '↗';
         const arrowMask = document.createElement('span');
         arrowMask.className = 'brandon-arrow-mask';
         arrowMask.style.color = originalColor;
+
+        const createArrowSVG = () => {
+          const ns = 'http://www.w3.org/2000/svg';
+          const svg = document.createElementNS(ns, 'svg');
+          svg.setAttribute('viewBox', '0 0 24 24');
+          const path = document.createElementNS(ns, 'path');
+          path.setAttribute('d', 'M4 12h12m0 0l-6-6m6 6l-6 6');
+          path.setAttribute('fill', 'none');
+          path.setAttribute('stroke', 'currentColor');
+          path.setAttribute('stroke-width', '2');
+          path.setAttribute('stroke-linecap', 'round');
+          path.setAttribute('stroke-linejoin', 'round');
+          svg.appendChild(path);
+          return svg;
+        };
+
         const arrowOne = document.createElement('span');
         arrowOne.className = 'brandon-arrow brandon-arrow-one';
-        arrowOne.textContent = arrowChar;
+        arrowOne.appendChild(createArrowSVG());
         const arrowTwo = document.createElement('span');
         arrowTwo.className = 'brandon-arrow brandon-arrow-two';
-        arrowTwo.textContent = arrowChar;
+        arrowTwo.appendChild(createArrowSVG());
         arrowMask.append(arrowOne, arrowTwo);
         link.append(arrowMask);
         link.classList.add(`brandon-arrow-${arrowDirection}`);

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-styles',
         get_stylesheet_uri(),
         array(),
-        '1.0.3'
+        '1.0.4'
     );
 
     // --- THIRD-PARTY LIBRARIES ---
@@ -65,7 +65,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-scripts',
         get_stylesheet_directory_uri() . '/brandon-custom-scripts.js',
         array('brandon-p5', 'brandon-gsap-ce', 'brandon-gsap-st', 'brandon-gsap-stg'),
-        '3.2.0', // Incremented version
+        '3.2.1', // Incremented version
         true
     );
 }

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
 	Description: Child Theme for Semplice
 	Author: Semplicelabs
 	Template: semplice7
-	Version: 1.0.2 - Arrow Animation Fix
+        Version: 1.0.4 - SVG Arrow
 */
 
 /* Custom CSS Start */
@@ -146,15 +146,29 @@
 }
 
 .brandon-arrow {
-	font-size: 1em;
-	display: inline-block;
-	position: absolute;
-	left: 50%;
-	top: 50%;
-	transform: translate(-50%, -50%);
-	transition: transform 0.45s var(--brandon-transition-ease);
-	will-change: transform;
-	pointer-events: none;
+        width: 1em;
+        height: 1em;
+        display: inline-block;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        transition: transform 0.45s var(--brandon-transition-ease);
+        will-change: transform;
+        pointer-events: none;
+}
+
+.brandon-arrow svg {
+        width: 100%;
+        height: 100%;
+        display: block;
+}
+
+.brandon-arrow-diag-up .brandon-arrow svg {
+        transform: rotate(-45deg);
+}
+.brandon-arrow-diag-down .brandon-arrow svg {
+        transform: rotate(45deg);
 }
 
 .brandon-animated-button-reveal.brandon-arrow-diag-up .brandon-arrow-one {
@@ -392,16 +406,22 @@ div.smp-code a.brandon-quicklink-style {
 	overflow: hidden;
 }
 .brandon-reveal-link-js .brandon-arrow {
-	font-size: 1em;
-	display: inline-block;
-	position: absolute;
-	left: 50%;
-	top: 50%;
-	transition: transform 0.45s var(--brandon-transition-ease);
-	will-change: transform;
-	pointer-events: none;
+        width: 1em;
+        height: 1em;
+        display: inline-block;
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transition: transform 0.45s var(--brandon-transition-ease);
+        will-change: transform;
+        pointer-events: none;
     /* The base position, which is centered. */
-    transform: translate(-50%, -50%); 
+    transform: translate(-50%, -50%);
+}
+.brandon-reveal-link-js .brandon-arrow svg {
+        width: 100%;
+        height: 100%;
+        display: block;
 }
 
 /*


### PR DESCRIPTION
## Summary
- replace font arrows with inline SVG icons
- size and rotate arrow SVG via CSS
- bump CSS and JS versions

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_685cd86594d08331bba60f110e483fba