### PR TITLE
Fix arrow size and cleanup

### DIFF
--- a/brandon-custom-scripts.js
+++ b/brandon-custom-scripts.js
@@ -495,7 +495,7 @@
           const svg = document.createElementNS(ns, 'svg');
           svg.setAttribute('viewBox', '0 0 24 24');
           const path = document.createElementNS(ns, 'path');
-          path.setAttribute('d', 'M4 12h12m0 0l-6-6m6 6l-6 6');
+          path.setAttribute('d', 'M4 12h12m0 0l-3-3m3 3l-3 3');
           path.setAttribute('fill', 'none');
           path.setAttribute('stroke', 'currentColor');
           path.setAttribute('stroke-width', strokeWidth);
@@ -505,9 +505,8 @@
           return svg;
         };
 
-        const computedWeight = parseInt(window.getComputedStyle(link).fontWeight, 10);
-        const numericWeight = isNaN(computedWeight) ? 400 : computedWeight;
-        const strokeWidth = Math.max(1, (numericWeight / 700) * 2).toFixed(2);
+        const rootStyles = window.getComputedStyle(document.documentElement);
+        const strokeWidth = parseFloat(rootStyles.getPropertyValue("--brandon-arrow-stroke-width")) || 2;
 
         const arrowOne = document.createElement('span');
         arrowOne.className = 'brandon-arrow brandon-arrow-one';

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-styles',
         get_stylesheet_uri(),
         array(),
-        '1.0.5'
+        '1.0.6'
     );
 
     // --- THIRD-PARTY LIBRARIES ---
@@ -65,7 +65,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-scripts',
         get_stylesheet_directory_uri() . '/brandon-custom-scripts.js',
         array('brandon-p5', 'brandon-gsap-ce', 'brandon-gsap-st', 'brandon-gsap-stg'),
-        '3.2.2', // Incremented version
+        '3.2.3', // Incremented version
         true
     );
 }

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
 	Description: Child Theme for Semplice
 	Author: Semplicelabs
 	Template: semplice7
-       Version: 1.0.5 - SVG Arrow
+       Version: 1.0.6 - Arrow tweaks
 */
 
 /* Custom CSS Start */
@@ -13,6 +13,7 @@
 	--brandon-dark-text-color: #0E0E10;
 	--brandon-accent-color: #0202ED;
 	--brandon-font-family: 'soehne-mono-buch', monospace, sans-serif;
+        --brandon-arrow-stroke-width: 2;
 	--brandon-font-size-base: 1.167rem;
 	--brandon-font-size-large: 18pt;
 	--brandon-font-size-small: 12pt;
@@ -59,7 +60,7 @@
 	display: inline-block;
 	position: relative;
 	overflow: hidden;
-	height: 1em;
+	height: 1.1em;
 	line-height: 1;
 }
 
@@ -138,16 +139,16 @@
 	display: inline-flex;
 	align-items: center;
 	justify-content: center;
-	width: 1em;
-	height: 1em;
+	width: 1.1em;
+	height: 1.1em;
 	margin-left: 8px;
 	position: relative;
 	overflow: hidden;
 }
 
 .brandon-arrow {
-        width: 1em;
-        height: 1em;
+        width: 1.1em;
+        height: 1.1em;
         display: inline-block;
         position: absolute;
         left: 50%;
@@ -396,33 +397,9 @@ div.smp-code a.brandon-quicklink-style {
 /* --- V4 Arrow Styling (FIXED) --- */
 
 .brandon-reveal-link-js .brandon-arrow-mask {
-	display: inline-flex;
-	align-items: center;
-	justify-content: center;
-	width: 1em;
-	height: 1em;
-	margin-left: 0.3em;
-	position: relative;
-	overflow: hidden;
+    margin-left: 0.3em;
 }
-.brandon-reveal-link-js .brandon-arrow {
-        width: 1em;
-        height: 1em;
-        display: inline-block;
-        position: absolute;
-        left: 50%;
-        top: 50%;
-        transition: transform 0.45s var(--brandon-transition-ease);
-        will-change: transform;
-        pointer-events: none;
-    /* The base position, which is centered. */
-    transform: translate(-50%, -50%);
-}
-.brandon-reveal-link-js .brandon-arrow svg {
-        width: 100%;
-        height: 100%;
-        display: block;
-}
+
 
 /*
  * Corrected symmetrical arrow paths for true 45-degree animations.


### PR DESCRIPTION
## Summary
- bump style and script versions
- size up arrow icons to 1.1em
- deduplicate reveal-link arrow CSS
- add CSS variable for arrow stroke width
- use new arrow path and read stroke width variable in JS

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685e28adc6a483319f02eaa14f3947bf