### PR TITLE
Fix split text masks and fade out text on scroll

### DIFF
--- a/brandon-custom-scripts.js
+++ b/brandon-custom-scripts.js
@@ -1,5 +1,5 @@
 // ==== BRANDON: GLOBAL SPA JS (Fully Optimized & Documented) ====
-// Version: 3.1.6 (Fonts Ready Hero Animation)
+// Version: 3.1.7 (Fonts Ready Hero Animation)
 // Date: 2025-06-25
 // Author: Brandon Leach
 // Description: Optimized custom animations and interactions for Semplice WordPress theme
@@ -553,20 +553,12 @@
           const split = new SplitText(textElement, { type: "words" });
           heroSplitInstances.push(split);
 
-          split.words.forEach(word => {
-            const mask = document.createElement('span');
-            mask.classList.add('brandon-word-mask');
-            mask.style.height = word.offsetHeight + 'px';
-            word.parentNode.insertBefore(mask, word);
-            mask.appendChild(word);
-          });
-
           if (split.words.length > 0) {
             masterTimeline.fromTo(
               split.words,
-              { y: 0 },
+              { autoAlpha: 1 },
               {
-                y: (i, target) => -target.offsetHeight,
+                autoAlpha: 0,
                 duration: 0.6,
                 ease: "power2.in",
                 stagger: { each: 0.03, from: "start" }
@@ -586,7 +578,7 @@
   }
 
   function initializeBrandonComponents() {
-    brandonLog("Initializing Brandon Components (v3.1.6)");
+    brandonLog("Initializing Brandon Components (v3.1.7)");
 
     if (!initializeGSAP()) return;
 
@@ -636,12 +628,6 @@
         if (instance && typeof instance.revert === 'function') {
             instance.revert();
         }
-    });
-    document.querySelectorAll('.brandon-word-mask').forEach(mask => {
-        while (mask.firstChild) {
-            mask.parentNode.insertBefore(mask.firstChild, mask);
-        }
-        mask.remove();
     });
     heroSplitInstances = [];
 

--- a/functions.php
+++ b/functions.php
@@ -20,7 +20,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-styles',
         get_stylesheet_uri(),
         array(),
-        '1.0.7'
+        '1.0.8'
     );
 
     // --- THIRD-PARTY LIBRARIES ---
@@ -65,7 +65,7 @@ function brandon_enqueue_custom_scripts() {
         'brandon-custom-scripts',
         get_stylesheet_directory_uri() . '/brandon-custom-scripts.js',
         array('brandon-p5', 'brandon-gsap-ce', 'brandon-gsap-st', 'brandon-gsap-stg'),
-        '3.2.6', // Incremented version
+        '3.2.7', // Incremented version
         true
     );
 }

--- a/style.css
+++ b/style.css
@@ -3,7 +3,7 @@
 	Description: Child Theme for Semplice
 	Author: Semplicelabs
 	Template: semplice7
-       Version: 1.0.7 - Arrow image
+       Version: 1.0.8 - Arrow image
 */
 
 /* Custom CSS Start */
@@ -428,12 +428,6 @@ div.smp-code a.brandon-quicklink-style {
     transform: translate(-50%, -50%); /* Enters at center */
 }
 
-.brandon-word-mask {
-    display: inline-block;
-    overflow: hidden;
-    vertical-align: top;
-    padding: 0.15em 0;
-}
 
 
 /* Custom CSS End */


### PR DESCRIPTION
## Summary
- remove masking from the hero scroll animation
- fade words out with opacity instead of sliding
- drop unused `.brandon-word-mask` styles
- bump asset versions

## Testing
- `php -l functions.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685eaec0a6788331b276869817cbf6cc