### PR TITLE
feat: toggle menu text between menu and close

### DIFF
--- a/brandon-custom-scripts.js
+++ b/brandon-custom-scripts.js
@@ -98,6 +98,7 @@
 
     const buttonSelector = '.brandon-animated-button-reveal, .brandon-logo-reveal-link';
     const workMenuSelector = '.brandon-work-menu-trigger';
+    let menuTextToggled = false;
     const pressEvents = ['mousedown', 'touchstart', 'keydown'];
     const releaseEvents = ['mouseup', 'mouseleave', 'touchend', 'touchcancel', 'keyup', 'blur'];
 
@@ -137,6 +138,21 @@
         } else {
           logDebug('Hamburger not found with common selectors.');
         }
+
+        // Toggle the menu text between "menu" and "close"
+        menuTextToggled = !menuTextToggled;
+        const newLabel = menuTextToggled ?
+          (workMenuTriggerElement.getAttribute('data-close-text') || 'close') :
+          (workMenuTriggerElement.getAttribute('data-open-text') || 'menu');
+
+        document.querySelectorAll(workMenuSelector).forEach(el => {
+          const topText = el.querySelector('.brandon-button-reveal-text.top');
+          const bottomText = el.querySelector('.brandon-button-reveal-text.bottom');
+          const calibrator = el.querySelector('.brandon-button-reveal-width-calibrator');
+          if (topText) topText.innerHTML = newLabel;
+          if (bottomText) bottomText.innerHTML = newLabel;
+          if (calibrator) calibrator.innerHTML = newLabel;
+        });
       }
     }, { capture: true });
   }


### PR DESCRIPTION
## Summary
- toggle `.brandon-work-menu-trigger` text between "menu" and "close" on click while preserving hover animation
- allow custom open/close labels via `data-open-text` and `data-close-text`

## Testing
- `node --version`
- `node --check brandon-custom-scripts.js`
- `npm test` *(fails: no package.json)*


------
https://chatgpt.com/codex/tasks/task_e_68b8d9fc57248331a8fa4aa2c59d0f60